### PR TITLE
Implement alias sequence and some traits

### DIFF
--- a/source/taurus/meta/usage.d
+++ b/source/taurus/meta/usage.d
@@ -1,0 +1,98 @@
+module taurus.meta.usage;
+
+// FIXME: copyright phobos
+/**
+ * Allows `alias`ing of any single symbol, type or compile-time expression.
+ *
+ * Not everything can be directly aliased. An alias cannot be declared of - for
+ *     example - a literal:
+ *
+ * Examples:
+ * --------------------
+ * alias a = 4; //Error
+ * alias b = Alias!4; //OK
+ * --------------------
+ */
+alias Alias(alias a) = a;
+
+
+///
+alias Alias(T) = T;
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+	// Without Alias this would fail if Args[0] was e.g. a value and
+	// some logic would be needed to detect when to use enum instead
+	alias Head(Args...) = Alias!(Args[0]);
+	alias Tail(Args...) = Args[1 .. $];
+
+	alias Blah = AliasSeq!(3, int, "hello");
+	static assert(Head!Blah == 3);
+	static assert(is(Head!(Tail!Blah) == int));
+	static assert((Tail!Blah)[1] == "hello");
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+	alias a = Alias!(123);
+	static assert(a == 123);
+
+	enum abc = 1;
+	alias b = Alias!(abc);
+	static assert(b == 1);
+
+	alias c = Alias!(3 + 4);
+	static assert(c == 7);
+
+	alias concat = (s0, s1) => s0 ~ s1;
+	alias d = Alias!(concat("Hello", " World!"));
+	static assert(d == "Hello World!");
+
+	alias e = Alias!(int);
+	static assert(is(e == int));
+
+	alias f = Alias!(AliasSeq!(int));
+	static assert(!is(typeof(f[0]))); //not an AliasSeq
+	static assert(is(f == int));
+
+	auto g = 6;
+	alias h = Alias!g;
+	++h;
+	assert(g == 7);
+}
+
+
+/**
+ * Creates a sequence of zero or more aliases. This is most commonly
+ *     used as template parameters or arguments.
+ */
+alias AliasSeq(TList...) = TList;
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+	import std.meta;
+	alias TL = AliasSeq!(int, double);
+
+	int foo(TL td)  // same as int foo(int, double);
+	{
+		return td[0] + cast(int) td[1];
+	}
+
+	assert(3 == foo(2, 1.0));
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+	alias TL = AliasSeq!(int, double);
+
+	alias Types = AliasSeq!(TL, char);
+	static assert(is(Types == AliasSeq!(int, double, char)));
+}

--- a/source/taurus/traits/types/behaviours.d
+++ b/source/taurus/traits/types/behaviours.d
@@ -1,0 +1,35 @@
+module taurus.traits.types.behaviours;
+
+// FIXME: copyright phobos
+/**
+ * Returns `true` if T can be iterated over using a `foreach` loop with
+ *     a single loop variable of automatically inferred type, regardless of how
+ *     the `foreach` loop is implemented.  This includes ranges, structs/classes
+ *     that define `opApply` with a single loop variable, and builtin dynamic,
+ *     static and associative arrays.
+ */
+enum bool isIterable(T) = is(typeof({ foreach (elem; T.init) {} }));
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+	struct OpApply
+	{
+		int opApply(scope int delegate(ref uint) dg) { assert(0); }
+	}
+
+	struct Range
+	{
+		@property uint front() { assert(0); }
+		void popFront() { assert(0); }
+		enum bool empty = false;
+	}
+
+	static assert( isIterable!(uint[]));
+	static assert( isIterable!OpApply);
+	static assert( isIterable!(uint[string]));
+	static assert( isIterable!Range);
+
+	static assert(!isIterable!uint);
+}

--- a/source/taurus/traits/types/behaviours.d
+++ b/source/taurus/traits/types/behaviours.d
@@ -33,3 +33,74 @@ unittest
 
 	static assert(!isIterable!uint);
 }
+
+
+/**
+ * Detect whether symbol or type `T` is a function, a function pointer or a delegate.
+ *
+ * Params: T = type to check.
+ *
+ * Returns: a `bool`.
+ */
+template isSomeFunction(T ...)
+	if (T.length == 1)
+{
+	static if ((is(typeof(& T[0]) U : U*) && is(U == function)) || is(typeof(& T[0]) U == delegate))
+	{
+		// T is a (nested) function symbol.
+		enum bool isSomeFunction = true;
+	}
+	else static if (is(T[0] W) || is(typeof(T[0]) W))
+	{
+		// T is an expression or a type.  Take the type of it and examine.
+		static if (is(W F : F*) && is(F == function))
+			enum bool isSomeFunction = true; // function pointer
+		else
+			enum bool isSomeFunction = is(W == function) || is(W == delegate);
+	}
+	else
+		enum bool isSomeFunction = false;
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+	static real func(ref int) { return 0; }
+	static void prop() @property { }
+	class C
+	{
+		real method(ref int) { return 0; }
+		real prop() @property { return 0; }
+	}
+	scope c = new C;
+	auto fp = &func;
+	auto dg = &c.method;
+	real val;
+
+	static assert( isSomeFunction!func);
+	static assert( isSomeFunction!prop);
+	static assert( isSomeFunction!(C.method));
+	static assert( isSomeFunction!(C.prop));
+	static assert( isSomeFunction!(c.prop));
+	static assert( isSomeFunction!(c.prop));
+	static assert( isSomeFunction!fp);
+	static assert( isSomeFunction!dg);
+
+	static assert(!isSomeFunction!int);
+	static assert(!isSomeFunction!val);
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+	void nestedFunc() { }
+	void nestedProp() @property { }
+	static assert(isSomeFunction!nestedFunc);
+	static assert(isSomeFunction!nestedProp);
+	static assert(isSomeFunction!(real function(ref int)));
+	static assert(isSomeFunction!(real delegate(ref int)));
+	static assert(isSomeFunction!((int a) { return a; }));
+	static assert(!isSomeFunction!isSomeFunction);
+}

--- a/source/taurus/traits/types/behaviours.d
+++ b/source/taurus/traits/types/behaviours.d
@@ -2,6 +2,82 @@ module taurus.traits.types.behaviours;
 
 // FIXME: copyright phobos
 /**
+ * Detect whether `T` is a callable object, which can be called with the
+ *     function call operator `$(LPAREN)...$(RPAREN)`.
+ */
+template isCallable(alias callable)
+{
+	static if (is(typeof(&callable.opCall) == delegate))
+		// T is a object which has a member function opCall().
+		enum bool isCallable = true;
+	else static if (is(typeof(&callable.opCall) V : V*) && is(V == function))
+		// T is a type which has a static member function opCall().
+		enum bool isCallable = true;
+	else static if (is(typeof(&callable!())))
+	{
+		alias TemplateInstanceType = typeof(&callable!());
+		enum bool isCallable = isCallable!TemplateInstanceType;
+	}
+	else
+	{
+		enum bool isCallable = isSomeFunction!callable;
+	}
+}
+
+/// Functions, lambdas, and aggregate types with (static) opCall.
+@safe pure nothrow @nogc
+unittest
+{
+	void f() { }
+	int g(int x) { return x; }
+
+	static assert( isCallable!f);
+	static assert( isCallable!g);
+
+	class C { int opCall(int) { return 0; } }
+	scope c = new C();
+	struct S { static int opCall(int) { return 0; } }
+	interface I { real value() @property; }
+
+	static assert( isCallable!c);
+	static assert( isCallable!(c.opCall));
+	static assert( isCallable!S);
+	static assert( isCallable!(I.value));
+	static assert( isCallable!((int a) { return a; }));
+
+	static assert(!isCallable!I);
+}
+
+/// Templates
+@safe pure nothrow @nogc
+unittest
+{
+	void f()() { }
+	T g(T = int)(T x) { return x; }
+
+	static assert( isCallable!f);
+	static assert( isCallable!g);
+}
+
+/// Overloaded functions and function templates.
+@safe pure nothrow @nogc
+unittest
+{
+	static struct Wrapper
+	{
+		void f() { }
+		int f(int x) { return x; }
+
+		void g()() { }
+		T g(T = int)(T x) { return x; }
+	}
+
+	static assert(isCallable!(Wrapper.f));
+	static assert(isCallable!(Wrapper.g));
+}
+
+
+/**
  * Returns `true` if T can be iterated over using a `foreach` loop with
  *     a single loop variable of automatically inferred type, regardless of how
  *     the `foreach` loop is implemented.  This includes ranges, structs/classes

--- a/source/taurus/traits/types/functions.d
+++ b/source/taurus/traits/types/functions.d
@@ -108,3 +108,66 @@ unittest
     alias F_dglit = FunctionTypeOf!((int a){ return a; });
     static assert(is(F_dglit* : int function(int)));
 }
+
+
+/**
+ * Get the type of the return value from a function, a pointer to function, a
+ *     delegate, a struct with an opCall, a pointer to a struct with an opCall,
+ *     or a class with an `opCall`.
+ */
+template ReturnType(func ...)
+if (func.length == 1 && isCallable!func)
+{
+    static if (is(FunctionTypeOf!func R == return))
+        alias ReturnType = R;
+    else
+        static assert(0, "argument has no return type");
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+    int foo();
+    ReturnType!foo x;   // x is declared as int
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+    struct G
+    {
+        int opCall (int i) { return 1;}
+    }
+
+    alias ShouldBeInt = ReturnType!G;
+    static assert(is(ShouldBeInt == int));
+
+    G g;
+    static assert(is(ReturnType!g == int));
+
+    G* p;
+    alias pg = ReturnType!p;
+    static assert(is(pg == int));
+
+    class C
+    {
+        int opCall (int i) { return 1;}
+    }
+
+    static assert(is(ReturnType!C == int));
+
+    C c;
+    static assert(is(ReturnType!c == int));
+
+    class Test
+    {
+        int prop() @property { return 0; }
+    }
+    alias R_Test_prop = ReturnType!(Test.prop);
+    static assert(is(R_Test_prop == int));
+
+    alias R_dglit = ReturnType!((int a) { return a; });
+    static assert(is(R_dglit == int));
+}

--- a/source/taurus/traits/types/functions.d
+++ b/source/taurus/traits/types/functions.d
@@ -1,0 +1,110 @@
+module taurus.traits.types.functions;
+
+import taurus.traits.types.behaviours : isCallable;
+
+// FIXME: copyright phobos
+/**
+ * Get the function type from a callable object `func`.
+ *
+ * Using builtin `typeof` on a property function yields the types of the
+ *     property value, not of the property function itself. Still, `FunctionTypeOf`
+ *     is able to obtain function types of properties.
+ *
+ * Note: do not confuse function types with function pointer types; function
+ *     types are usually used for compile-time reflection purposes.
+ */
+template FunctionTypeOf(func...)
+if (func.length == 1 && isCallable!func)
+{
+    static if (is(typeof(& func[0]) Fsym : Fsym*) && is(Fsym == function) || is(typeof(& func[0]) Fsym == delegate))
+    {
+        alias FunctionTypeOf = Fsym; // HIT: (nested) function symbol
+    }
+    else static if (is(typeof(& func[0].opCall) Fobj == delegate))
+    {
+        alias FunctionTypeOf = Fobj; // HIT: callable object
+    }
+    else static if (is(typeof(& func[0].opCall) Ftyp : Ftyp*) && is(Ftyp == function))
+    {
+        alias FunctionTypeOf = Ftyp; // HIT: callable type
+    }
+    else static if (is(func[0] T) || is(typeof(func[0]) T))
+    {
+        static if (is(T == function))
+            alias FunctionTypeOf = T;    // HIT: function
+        else static if (is(T Fptr : Fptr*) && is(Fptr == function))
+            alias FunctionTypeOf = Fptr; // HIT: function pointer
+        else static if (is(T Fdlg == delegate))
+            alias FunctionTypeOf = Fdlg; // HIT: delegate
+        else
+            static assert(0);
+    }
+    else
+        static assert(0);
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+    class C
+    {
+        int value() @property { return 0; }
+    }
+    static assert(is( typeof(C.value) == int ));
+    static assert(is( FunctionTypeOf!(C.value) == function ));
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+    @safe pure nothrow @nogc int test(int a);
+    @safe pure nothrow @nogc int propGet() @property;
+    @safe pure nothrow @nogc int propSet(int a) @property;
+    int function(int) @safe pure nothrow @nogc test_fp;
+    int delegate(int) @safe pure nothrow @nogc test_dg;
+    static assert(is( typeof(test) == FunctionTypeOf!(typeof(test)) ));
+    static assert(is( typeof(test) == FunctionTypeOf!test ));
+    static assert(is( typeof(test) == FunctionTypeOf!test_fp ));
+    static assert(is( typeof(test) == FunctionTypeOf!test_dg ));
+    alias int GetterType() @safe pure nothrow @nogc @property;
+    alias int SetterType(int) @safe pure nothrow @nogc @property;
+    static assert(is( FunctionTypeOf!propGet == GetterType ));
+    static assert(is( FunctionTypeOf!propSet == SetterType ));
+
+    interface Prop { int prop() @safe pure nothrow @nogc @property; }
+    Prop prop;
+    static assert(is( FunctionTypeOf!(Prop.prop) == GetterType ));
+    static assert(is( FunctionTypeOf!(prop.prop) == GetterType ));
+
+    class Callable { @safe pure nothrow @nogc int opCall(int) { return 0; } }
+    scope call = new Callable;
+    static assert(is( FunctionTypeOf!call == typeof(test) ));
+
+    struct StaticCallable { static pure nothrow @nogc int opCall(int) { return 0; } }
+    StaticCallable stcall_val;
+    StaticCallable* stcall_ptr;
+    static assert(is( FunctionTypeOf!stcall_val == typeof(test) ));
+    static assert(is( FunctionTypeOf!stcall_ptr == typeof(test) ));
+
+    interface Overloads
+    {
+        void test(string);
+        real test(real);
+        int  test(int);
+        int  test() @property;
+    }
+    alias ov = __traits(getVirtualFunctions, Overloads, "test");
+    alias F_ov0 = FunctionTypeOf!(ov[0]);
+    alias F_ov1 = FunctionTypeOf!(ov[1]);
+    alias F_ov2 = FunctionTypeOf!(ov[2]);
+    alias F_ov3 = FunctionTypeOf!(ov[3]);
+    static assert(is(F_ov0* == void function(string)));
+    static assert(is(F_ov1* == real function(real)));
+    static assert(is(F_ov2* == int function(int)));
+    static assert(is(F_ov3* == int function() @property));
+
+    alias F_dglit = FunctionTypeOf!((int a){ return a; });
+    static assert(is(F_dglit* : int function(int)));
+}


### PR DESCRIPTION
`taurus.meta`
* added Alias
* added AliasSeq

`taurus.traits.types.functions`
* added FunctionTypeOf
* added ReturnType

`taurus.traits.types.behaviours`
* added isCallable
* added isIterable
* added isSomeFunction

These are some common utilities used all around Phobos. Some unittests suffered changes like using `scope` to instantiate classes, this way GC isn't used and added @safe pure nothrow @nogc in every unittest.

Folder and files's names are not final!