### PR TITLE
Bump github workflows version to support frontend, druntime and phobos since 2.094

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,9 +7,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        dc: [dmd-latest, ldc-latest, dmd-2.085.0, ldc-1.18.0]
+        dc: [dmd-latest, ldc-latest, dmd-2.094.0, ldc-1.24.0]
         exclude:
-          - { os: macOS-latest, dc: dmd-2.085.0 }
+          - { os: macOS-latest, dc: dmd-2.094.0 }
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Although `SumType` has been added only in the latest version `2.097`, the original package supported the frontend since `2.094`, so that's what we're going with.